### PR TITLE
Fix broken reconnect logic.

### DIFF
--- a/pyotgw/protocol.py
+++ b/pyotgw/protocol.py
@@ -20,8 +20,7 @@ import asyncio
 import logging
 import re
 import struct
-from asyncio.queues import QueueFull
-from queue import Empty
+from asyncio.queues import QueueFull, QueueEmpty
 
 from .vars import *
 
@@ -65,14 +64,8 @@ class protocol(asyncio.Protocol):
             while not q.empty():
                 try:
                     q.get_nowait()
-                except Empty:
+                except QueueEmpty:
                     continue
-
-        # If you cancel the watchdog task here, it never
-        # gets triggerd, and thus never reconnects. Commented for now.
-
-        # if self._watchdog_task is not None:
-        # self._watchdog_task.cancel()
 
         if self._report_task is not None:
             self._report_task.cancel()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="pyotgw",
-    version="0.4b2",
+    version="0.4b1",
     author="Milan van Nugteren",
     author_email="milan@network23.nl",
     description=("A library to interface with the opentherm gateway through "

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="pyotgw",
-    version="0.4b1",
+    version="0.4b2",
     author="Milan van Nugteren",
     author_email="milan@network23.nl",
     description=("A library to interface with the opentherm gateway through "


### PR DESCRIPTION
q.get() is a coroutine, however, we are not in a coroutine.
Replace with q.get_nowait() and wrap in try, except.

Also, on disconnect the watchdog task is unscheduled.
This causes pyotgw to not reconnect on disconnect. Removed.

Fixes issue #2

I've also bumped the version so this can be released easily and asap.