### PR TITLE
Fix bug during disconnect handling

### DIFF
--- a/pyotgw/protocol.py
+++ b/pyotgw/protocol.py
@@ -65,7 +65,7 @@ class protocol(asyncio.Protocol):
         if self._report_task is not None:
             self._report_task.cancel()
         self._msg_task.cancel()
-        for q in [self._cmdq, self._updateq, self.msgq]:
+        for q in [self._cmdq, self._updateq, self._msgq]:
             while not q.empty():
                 q.get_nowait()
         self.status = {}


### PR DESCRIPTION
fixes: 
```
2019-04-16 20:44:26 ERROR (MainThread) [homeassistant.core] Error doing job: Exception in callback <bound method SerialTransport._call_connection_lost of SerialTransport(None, None, None)>
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 68, in uvloop.loop.Handle._run
  File "/usr/local/lib/python3.7/site-packages/serial_asyncio/__init__.py", line 399, in _call_connection_lost
    self._protocol.connection_lost(exc)
  File "/usr/local/lib/python3.7/site-packages/pyotgw/protocol.py", line 68, in connection_lost
    for q in [self._cmdq, self._updateq, self.msgq]:
AttributeError: 'protocol' object has no attribute 'msgq'
```