### PR TITLE
 Add Python version to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     keywords="opentherm gateway otgw",
     url="https://github.com/mvn23/pyotgw",
     packages=["pyotgw"],
+    python_requires='>=3.7',
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=["pyserial-asyncio"],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     keywords="opentherm gateway otgw",
     url="https://github.com/mvn23/pyotgw",
     packages=["pyotgw"],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=["pyserial-asyncio"],


### PR DESCRIPTION
Home assistant supports Python 3.7+: https://github.com/home-assistant/core/blob/dev/homeassistant/const.py#L7

For pyotgw this would be sensible to give this as an indicator as well.