### PR TITLE
[WIP] Separate thermostat, boiler and otgw status

### DIFF
--- a/pyotgw/protocol.py
+++ b/pyotgw/protocol.py
@@ -51,7 +51,7 @@ class protocol(asyncio.Protocol):
         self._msg_task = self.loop.create_task(self._process_msgs())
         self._report_task = None
         self._watchdog_task = None
-        self.status = {}
+        self.status = {v.BOILER: {}, v.OTGW: {}, v.THERMOSTAT: {}}
         self.connected = True
 
     def connection_lost(self, exc):
@@ -243,109 +243,104 @@ class protocol(asyncio.Protocol):
         Process message and update status variables where necessary.
         Add status to queue if it was changed in the process.
         """
-        # Ignore output to the thermostat ('A') except MSG_TROVRD,
-        # MSG_TOUTSIDE and MSG_ROVRD as they may contain useful values.
-        # Other messages cause issues when overriding values sent to the
-        # boiler.
-        if src == "A" and msgid not in [v.MSG_TROVRD, v.MSG_TOUTSIDE, v.MSG_ROVRD]:
-            return
-        # Ignore upstream MSG_TROVRD if override is active on the gateway.
-        if (
-            src == "B"
-            and msgid == v.MSG_TROVRD
-            and self.status.get(v.DATA_ROOM_SETPOINT_OVRD)
-        ):
-            return
+        if src in "TA":
+            statuspart = self.status[v.THERMOSTAT]
+        else:  # src in "BR"
+            statuspart = self.status[v.BOILER]
+
         if msgtype in (v.READ_DATA, v.WRITE_DATA):
             # Data sent from thermostat
             if msgid == v.MSG_STATUS:
                 # Master sends status
                 thermo_status = self._get_flag8(msb)
-                self.status[v.DATA_MASTER_CH_ENABLED] = thermo_status[0]
-                self.status[v.DATA_MASTER_DHW_ENABLED] = thermo_status[1]
-                self.status[v.DATA_MASTER_COOLING_ENABLED] = thermo_status[2]
-                self.status[v.DATA_MASTER_OTC_ENABLED] = thermo_status[3]
-                self.status[v.DATA_MASTER_CH2_ENABLED] = thermo_status[4]
+                statuspart[v.DATA_MASTER_CH_ENABLED] = thermo_status[0]
+                statuspart[v.DATA_MASTER_DHW_ENABLED] = thermo_status[1]
+                statuspart[v.DATA_MASTER_COOLING_ENABLED] = thermo_status[2]
+                statuspart[v.DATA_MASTER_OTC_ENABLED] = thermo_status[3]
+                statuspart[v.DATA_MASTER_CH2_ENABLED] = thermo_status[4]
             elif msgid == v.MSG_MCONFIG:
                 # Master sends ID
-                self.status[v.DATA_MASTER_MEMBERID] = self._get_u8(lsb)
+                statuspart[v.DATA_MASTER_MEMBERID] = self._get_u8(lsb)
             elif msgid == v.MSG_TRSET:
                 # Master changes room setpoint, support by the boiler
                 # is not mandatory, but we want the data regardless
-                self.status[v.DATA_ROOM_SETPOINT] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_ROOM_SETPOINT] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TRSET2:
                 # Master changes room setpoint 2, support by the boiler
                 # is not mandatory, but we want the data regardless
-                self.status[v.DATA_ROOM_SETPOINT_2] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_ROOM_SETPOINT_2] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TROOM:
                 # Master reports sensed room temperature
-                self.status[v.DATA_ROOM_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_ROOM_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_OTVERM:
                 # Master reports OpenTherm version
-                self.status[v.DATA_MASTER_OT_VERSION] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_MASTER_OT_VERSION] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_MVER:
                 # Master reports product type and version
-                self.status[v.DATA_MASTER_PRODUCT_TYPE] = self._get_u8(msb)
-                self.status[v.DATA_MASTER_PRODUCT_VERSION] = self._get_u8(lsb)
+                statuspart[v.DATA_MASTER_PRODUCT_TYPE] = self._get_u8(msb)
+                statuspart[v.DATA_MASTER_PRODUCT_VERSION] = self._get_u8(lsb)
         elif msgtype in (v.READ_ACK, v.WRITE_ACK):
             # Data sent from boiler
             if msgid == v.MSG_STATUS:
                 # Slave reports status
                 boiler_status = self._get_flag8(lsb)
-                self.status[v.DATA_SLAVE_FAULT_IND] = boiler_status[0]
-                self.status[v.DATA_SLAVE_CH_ACTIVE] = boiler_status[1]
-                self.status[v.DATA_SLAVE_DHW_ACTIVE] = boiler_status[2]
-                self.status[v.DATA_SLAVE_FLAME_ON] = boiler_status[3]
-                self.status[v.DATA_SLAVE_COOLING_ACTIVE] = boiler_status[4]
-                self.status[v.DATA_SLAVE_CH2_ACTIVE] = boiler_status[5]
-                self.status[v.DATA_SLAVE_DIAG_IND] = boiler_status[6]
+                statuspart[v.DATA_SLAVE_FAULT_IND] = boiler_status[0]
+                statuspart[v.DATA_SLAVE_CH_ACTIVE] = boiler_status[1]
+                statuspart[v.DATA_SLAVE_DHW_ACTIVE] = boiler_status[2]
+                statuspart[v.DATA_SLAVE_FLAME_ON] = boiler_status[3]
+                statuspart[v.DATA_SLAVE_COOLING_ACTIVE] = boiler_status[4]
+                statuspart[v.DATA_SLAVE_CH2_ACTIVE] = boiler_status[5]
+                statuspart[v.DATA_SLAVE_DIAG_IND] = boiler_status[6]
             elif msgid == v.MSG_TSET:
                 # Slave confirms CH water setpoint
-                self.status[v.DATA_CONTROL_SETPOINT] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_CONTROL_SETPOINT] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_SCONFIG:
                 # Slave reports config and ID
                 slave_status = self._get_flag8(msb)
-                self.status[v.DATA_SLAVE_DHW_PRESENT] = slave_status[0]
-                self.status[v.DATA_SLAVE_CONTROL_TYPE] = slave_status[1]
-                self.status[v.DATA_SLAVE_COOLING_SUPPORTED] = slave_status[2]
-                self.status[v.DATA_SLAVE_DHW_CONFIG] = slave_status[3]
-                self.status[v.DATA_SLAVE_MASTER_LOW_OFF_PUMP] = slave_status[4]
-                self.status[v.DATA_SLAVE_CH2_PRESENT] = slave_status[5]
-                self.status[v.DATA_SLAVE_MEMBERID] = self._get_u8(lsb)
+                statuspart[v.DATA_SLAVE_DHW_PRESENT] = slave_status[0]
+                statuspart[v.DATA_SLAVE_CONTROL_TYPE] = slave_status[1]
+                statuspart[v.DATA_SLAVE_COOLING_SUPPORTED] = slave_status[2]
+                statuspart[v.DATA_SLAVE_DHW_CONFIG] = slave_status[3]
+                statuspart[v.DATA_SLAVE_MASTER_LOW_OFF_PUMP] = slave_status[4]
+                statuspart[v.DATA_SLAVE_CH2_PRESENT] = slave_status[5]
+                statuspart[v.DATA_SLAVE_MEMBERID] = self._get_u8(lsb)
             elif msgid == v.MSG_COMMAND:
                 # TODO: implement command notification system
                 pass
             elif msgid == v.MSG_ASFFLAGS:
                 # Slave reports fault flags
                 fault_flags = self._get_flag8(msb)
-                self.status[v.DATA_SLAVE_SERVICE_REQ] = fault_flags[0]
-                self.status[v.DATA_SLAVE_REMOTE_RESET] = fault_flags[1]
-                self.status[v.DATA_SLAVE_LOW_WATER_PRESS] = fault_flags[2]
-                self.status[v.DATA_SLAVE_GAS_FAULT] = fault_flags[3]
-                self.status[v.DATA_SLAVE_AIR_PRESS_FAULT] = fault_flags[4]
-                self.status[v.DATA_SLAVE_WATER_OVERTEMP] = fault_flags[5]
-                self.status[v.DATA_SLAVE_OEM_FAULT] = self._get_u8(lsb)
+                statuspart[v.DATA_SLAVE_SERVICE_REQ] = fault_flags[0]
+                statuspart[v.DATA_SLAVE_REMOTE_RESET] = fault_flags[1]
+                statuspart[v.DATA_SLAVE_LOW_WATER_PRESS] = fault_flags[2]
+                statuspart[v.DATA_SLAVE_GAS_FAULT] = fault_flags[3]
+                statuspart[v.DATA_SLAVE_AIR_PRESS_FAULT] = fault_flags[4]
+                statuspart[v.DATA_SLAVE_WATER_OVERTEMP] = fault_flags[5]
+                statuspart[v.DATA_SLAVE_OEM_FAULT] = self._get_u8(lsb)
             elif msgid == v.MSG_RBPFLAGS:
                 # Slave reports remote parameters
                 transfer_flags = self._get_flag8(msb)
                 rw_flags = self._get_flag8(lsb)
-                self.status[v.DATA_REMOTE_TRANSFER_DHW] = transfer_flags[0]
-                self.status[v.DATA_REMOTE_TRANSFER_MAX_CH] = transfer_flags[1]
-                self.status[v.DATA_REMOTE_RW_DHW] = rw_flags[0]
-                self.status[v.DATA_REMOTE_RW_MAX_CH] = rw_flags[1]
+                statuspart[v.DATA_REMOTE_TRANSFER_DHW] = transfer_flags[0]
+                statuspart[v.DATA_REMOTE_TRANSFER_MAX_CH] = transfer_flags[1]
+                statuspart[v.DATA_REMOTE_RW_DHW] = rw_flags[0]
+                statuspart[v.DATA_REMOTE_RW_MAX_CH] = rw_flags[1]
             elif msgid == v.MSG_COOLING:
                 # Only report cooling control signal if slave acks it
-                self.status[v.DATA_COOLING_CONTROL] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_COOLING_CONTROL] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TSETC2:
                 # Slave confirms CH2 water setpoint
-                self.status[v.DATA_CONTROL_SETPOINT_2] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_CONTROL_SETPOINT_2] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TROVRD:
                 # OTGW (or downstream device) reports remote override
                 ovrd_value = self._get_f8_8(msb, lsb)
                 if ovrd_value > 0:
                     # iSense quirk: the gateway keeps sending override value
                     # even if the thermostat has cancelled the override.
-                    if self.status.get(v.OTGW_THRM_DETECT) == "I":
+                    if (
+                        self.status[v.OTGW].get(v.OTGW_THRM_DETECT) == "I"
+                        and src == "A"
+                    ):
                         ovrd = await self.issue_cmd(
                             v.OTGW_CMD_REPORT, v.OTGW_REPORT_SETPOINT_OVRD
                         )
@@ -355,113 +350,113 @@ class protocol(asyncio.Protocol):
                         if not match:
                             return
                         if match.group(1) in "Nn":
-                            if v.DATA_ROOM_SETPOINT_OVRD in self.status:
-                                del self.status[v.DATA_ROOM_SETPOINT_OVRD]
+                            if v.DATA_ROOM_SETPOINT_OVRD in statuspart:
+                                del statuspart[v.DATA_ROOM_SETPOINT_OVRD]
                         elif match.group(2):
-                            self.status[v.DATA_ROOM_SETPOINT_OVRD] = float(
+                            statuspart[v.DATA_ROOM_SETPOINT_OVRD] = float(
                                 match.group(2)
                             )
                     else:
-                        self.status[v.DATA_ROOM_SETPOINT_OVRD] = ovrd_value
-                elif self.status.get(v.DATA_ROOM_SETPOINT_OVRD):
-                    del self.status[v.DATA_ROOM_SETPOINT_OVRD]
+                        statuspart[v.DATA_ROOM_SETPOINT_OVRD] = ovrd_value
+                elif statuspart.get(v.DATA_ROOM_SETPOINT_OVRD):
+                    del statuspart[v.DATA_ROOM_SETPOINT_OVRD]
             elif msgid == v.MSG_MAXRMOD:
                 # Slave reports maximum modulation level
-                self.status[v.DATA_SLAVE_MAX_RELATIVE_MOD] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_SLAVE_MAX_RELATIVE_MOD] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_MAXCAPMINMOD:
                 # Slave reports max capaxity and min modulation level
-                self.status[v.DATA_SLAVE_MAX_CAPACITY] = self._get_u8(msb)
-                self.status[v.DATA_SLAVE_MIN_MOD_LEVEL] = self._get_u8(lsb)
+                statuspart[v.DATA_SLAVE_MAX_CAPACITY] = self._get_u8(msb)
+                statuspart[v.DATA_SLAVE_MIN_MOD_LEVEL] = self._get_u8(lsb)
             elif msgid == v.MSG_RELMOD:
                 # Slave reports relative modulation level
-                self.status[v.DATA_REL_MOD_LEVEL] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_REL_MOD_LEVEL] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_CHPRESS:
                 # Slave reports CH circuit pressure
-                self.status[v.DATA_CH_WATER_PRESS] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_CH_WATER_PRESS] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_DHWFLOW:
                 # Slave reports DHW flow rate
-                self.status[v.DATA_DHW_FLOW_RATE] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_DHW_FLOW_RATE] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TBOILER:
                 # Slave reports CH water temperature
-                self.status[v.DATA_CH_WATER_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_CH_WATER_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TDHW:
                 # Slave reports DHW temperature
-                self.status[v.DATA_DHW_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_DHW_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TOUTSIDE:
                 # OTGW (or downstream device) reports outside temperature
-                self.status[v.DATA_OUTSIDE_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_OUTSIDE_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TRET:
                 # Slave reports return water temperature
-                self.status[v.DATA_RETURN_WATER_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_RETURN_WATER_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TSTOR:
                 # Slave reports solar storage temperature
-                self.status[v.DATA_SOLAR_STORAGE_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_SOLAR_STORAGE_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TCOLL:
                 # Slave reports solar collector temperature
-                self.status[v.DATA_SOLAR_COLL_TEMP] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_SOLAR_COLL_TEMP] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TFLOWCH2:
                 # Slave reports CH2 water temperature
-                self.status[v.DATA_CH_WATER_TEMP_2] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_CH_WATER_TEMP_2] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TDHW2:
                 # Slave reports DHW2 temperature
-                self.status[v.DATA_DHW_TEMP_2] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_DHW_TEMP_2] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_TEXHAUST:
                 # Slave reports exhaust temperature
-                self.status[v.DATA_EXHAUST_TEMP] = self._get_s16(msb, lsb)
+                statuspart[v.DATA_EXHAUST_TEMP] = self._get_s16(msb, lsb)
             elif msgid == v.MSG_TDHWSETUL:
                 # Slave reports min/max DHW setpoint
-                self.status[v.DATA_SLAVE_DHW_MAX_SETP] = self._get_s8(msb)
-                self.status[v.DATA_SLAVE_DHW_MIN_SETP] = self._get_s8(lsb)
+                statuspart[v.DATA_SLAVE_DHW_MAX_SETP] = self._get_s8(msb)
+                statuspart[v.DATA_SLAVE_DHW_MIN_SETP] = self._get_s8(lsb)
             elif msgid == v.MSG_TCHSETUL:
                 # Slave reports min/max CH setpoint
-                self.status[v.DATA_SLAVE_CH_MAX_SETP] = self._get_s8(msb)
-                self.status[v.DATA_SLAVE_CH_MIN_SETP] = self._get_s8(lsb)
+                statuspart[v.DATA_SLAVE_CH_MAX_SETP] = self._get_s8(msb)
+                statuspart[v.DATA_SLAVE_CH_MIN_SETP] = self._get_s8(lsb)
             elif msgid == v.MSG_TDHWSET:
                 # Slave reports or acks DHW setpoint
-                self.status[v.DATA_DHW_SETPOINT] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_DHW_SETPOINT] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_MAXTSET:
                 # Slave reports or acks max CH setpoint
-                self.status[v.DATA_MAX_CH_SETPOINT] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_MAX_CH_SETPOINT] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_ROVRD:
                 # OTGW (or downstream device) reports remote override
                 # behaviour
                 rovrd_flags = self._get_flag8(lsb)
-                self.status[v.DATA_ROVRD_MAN_PRIO] = rovrd_flags[0]
-                self.status[v.DATA_ROVRD_AUTO_PRIO] = rovrd_flags[1]
+                statuspart[v.DATA_ROVRD_MAN_PRIO] = rovrd_flags[0]
+                statuspart[v.DATA_ROVRD_AUTO_PRIO] = rovrd_flags[1]
             elif msgid == v.MSG_OEMDIAG:
                 # Slave reports diagnostic info
-                self.status[v.DATA_OEM_DIAG] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_OEM_DIAG] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_BURNSTARTS:
                 # Slave reports burner starts
-                self.status[v.DATA_TOTAL_BURNER_STARTS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_TOTAL_BURNER_STARTS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_CHPUMPSTARTS:
                 # Slave reports CH pump starts
-                self.status[v.DATA_CH_PUMP_STARTS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_CH_PUMP_STARTS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_DHWPUMPSTARTS:
                 # Slave reports DHW pump starts
-                self.status[v.DATA_DHW_PUMP_STARTS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_DHW_PUMP_STARTS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_DHWBURNSTARTS:
                 # Slave reports DHW burner starts
-                self.status[v.DATA_DHW_BURNER_STARTS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_DHW_BURNER_STARTS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_BURNHRS:
                 # Slave reports CH burner hours
-                self.status[v.DATA_TOTAL_BURNER_HOURS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_TOTAL_BURNER_HOURS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_CHPUMPHRS:
                 # Slave reports CH pump hours
-                self.status[v.DATA_CH_PUMP_HOURS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_CH_PUMP_HOURS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_DHWPUMPHRS:
                 # Slave reports DHW pump hours
-                self.status[v.DATA_DHW_PUMP_HOURS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_DHW_PUMP_HOURS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_DHWBURNHRS:
                 # Slave reports DHW burner hours
-                self.status[v.DATA_DHW_BURNER_HOURS] = self._get_u16(msb, lsb)
+                statuspart[v.DATA_DHW_BURNER_HOURS] = self._get_u16(msb, lsb)
             elif msgid == v.MSG_OTVERS:
                 # Slave reports OpenTherm version
-                self.status[v.DATA_SLAVE_OT_VERSION] = self._get_f8_8(msb, lsb)
+                statuspart[v.DATA_SLAVE_OT_VERSION] = self._get_f8_8(msb, lsb)
             elif msgid == v.MSG_SVER:
                 # Slave reports product type and version
-                self.status[v.DATA_SLAVE_PRODUCT_TYPE] = self._get_u8(msb)
-                self.status[v.DATA_SLAVE_PRODUCT_VERSION] = self._get_u8(lsb)
+                statuspart[v.DATA_SLAVE_PRODUCT_TYPE] = self._get_u8(msb)
+                statuspart[v.DATA_SLAVE_PRODUCT_VERSION] = self._get_u8(lsb)
         self._updateq.put_nowait(dict(self.status))
 
     def _get_flag8(self, byte):

--- a/pyotgw/pyotgw.py
+++ b/pyotgw/pyotgw.py
@@ -158,7 +158,7 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(v.DATA_ROOM_TEMP)
+        return self._protocol.status[v.THERMOSTAT].get(v.DATA_ROOM_TEMP)
 
     def get_target_temp(self):
         """
@@ -166,10 +166,10 @@ class pyotgw:
         """
         if not self._connected:
             return
-        temp_ovrd = self._protocol.status.get(v.DATA_ROOM_SETPOINT_OVRD)
+        temp_ovrd = self._protocol.status[v.THERMOSTAT].get(v.DATA_ROOM_SETPOINT_OVRD)
         if temp_ovrd:
             return temp_ovrd
-        return self._protocol.status.get(v.DATA_ROOM_SETPOINT)
+        return self._protocol.status[v.THERMOSTAT].get(v.DATA_ROOM_SETPOINT)
 
     async def set_target_temp(
         self, temp, temporary=True, timeout=v.OTGW_DEFAULT_TIMEOUT
@@ -184,23 +184,25 @@ class pyotgw:
         """
         cmd = v.OTGW_CMD_TARGET_TEMP if temporary else v.OTGW_CMD_TARGET_TEMP_CONST
         value = f"{temp:2.1f}"
-        status = {}
+        status_otgw = {}
+        status_thermostat = {}
         ret = await self._wait_for_cmd(cmd, value, timeout)
         if ret is None:
             return
         ret = float(ret)
         if 0 <= ret <= 30:
             if ret == 0:
-                status[v.OTGW_SETP_OVRD_MODE] = v.OTGW_SETP_OVRD_DISABLED
-                status[v.DATA_ROOM_SETPOINT_OVRD] = None
+                status_otgw[v.OTGW_SETP_OVRD_MODE] = v.OTGW_SETP_OVRD_DISABLED
+                status_thermostat[v.DATA_ROOM_SETPOINT_OVRD] = None
             else:
                 if temporary:
                     ovrd_mode = v.OTGW_SETP_OVRD_TEMPORARY
                 else:
                     ovrd_mode = v.OTGW_SETP_OVRD_PERMANENT
-                status[v.OTGW_SETP_OVRD_MODE] = ovrd_mode
-                status[v.DATA_ROOM_SETPOINT_OVRD] = ret
-            self._update_status(status)
+                status_otgw[v.OTGW_SETP_OVRD_MODE] = ovrd_mode
+                status_thermostat[v.DATA_ROOM_SETPOINT_OVRD] = ret
+            self._update_status(v.OTGW, status_otgw)
+            self._update_status(v.THERMOSTAT, status_thermostat)
             return ret
 
     def get_outside_temp(self):
@@ -209,7 +211,9 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(v.DATA_OUTSIDE_TEMP)
+        return self._protocol.status[v.THERMOSTAT].get(
+            v.DATA_OUTSIDE_TEMP
+        ) or self._protocol.status[v.BOILER].get(v.DATA_OUTSIDE_TEMP)
 
     async def set_outside_temp(self, temp, timeout=v.OTGW_DEFAULT_TIMEOUT):
         """
@@ -224,7 +228,7 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_OUTSIDE_TEMP
-        status = {}
+        status_thermostat = {}
         if temp < -40:
             return None
         value = f"{temp:2.1f}"
@@ -234,10 +238,10 @@ class pyotgw:
         if ret not in ["-", None]:
             ret = float(ret)
         if ret == "-":
-            status[v.DATA_OUTSIDE_TEMP] = 0.0
+            status_thermostat[v.DATA_OUTSIDE_TEMP] = 0.0
         else:
-            status[v.DATA_OUTSIDE_TEMP] = ret
-        self._update_status(status)
+            status_thermostat[v.DATA_OUTSIDE_TEMP] = ret
+        self._update_status(v.THERMOSTAT, status_thermostat)
         return ret
 
     async def set_clock(self, date=datetime.now(), timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -262,7 +266,7 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(v.OTGW_DHW_OVRD)
+        return self._protocol.status[v.OTGW].get(v.OTGW_DHW_OVRD)
 
     async def get_reports(self):
         """
@@ -279,7 +283,7 @@ class pyotgw:
                 reports[value] = None
                 continue
             reports[value] = ret[2:]
-        status = {
+        status_otgw = {
             v.OTGW_ABOUT: reports.get(v.OTGW_REPORT_ABOUT),
             v.OTGW_BUILD: reports.get(v.OTGW_REPORT_BUILDDATE),
             v.OTGW_CLOCKMHZ: reports.get(v.OTGW_REPORT_CLOCKMHZ),
@@ -291,15 +295,15 @@ class pyotgw:
         ovrd_mode = reports.get(v.OTGW_REPORT_SETPOINT_OVRD)
         if ovrd_mode is not None:
             ovrd_mode = str.upper(ovrd_mode[0])
-            status.update({v.OTGW_SETP_OVRD_MODE: ovrd_mode})
+            status_otgw.update({v.OTGW_SETP_OVRD_MODE: ovrd_mode})
         gpio_funcs = reports.get(v.OTGW_REPORT_GPIO_FUNCS)
         if gpio_funcs is not None:
-            status.update(
+            status_otgw.update(
                 {v.OTGW_GPIO_A: int(gpio_funcs[0]), v.OTGW_GPIO_B: int(gpio_funcs[1])}
             )
         led_funcs = reports.get(v.OTGW_REPORT_LED_FUNCS)
         if led_funcs is not None:
-            status.update(
+            status_otgw.update(
                 {
                     v.OTGW_LED_A: led_funcs[0],
                     v.OTGW_LED_B: led_funcs[1],
@@ -311,7 +315,7 @@ class pyotgw:
             )
         tweaks = reports.get(v.OTGW_REPORT_TWEAKS)
         if tweaks is not None:
-            status.update(
+            status_otgw.update(
                 {
                     v.OTGW_IGNORE_TRANSITIONS: int(tweaks[0]),
                     v.OTGW_OVRD_HB: int(tweaks[1]),
@@ -319,15 +323,18 @@ class pyotgw:
             )
         sb_temp = reports.get(v.OTGW_REPORT_SETBACK_TEMP)
         if sb_temp is not None:
-            status.update({v.OTGW_SB_TEMP: float(sb_temp)})
+            status_otgw.update({v.OTGW_SB_TEMP: float(sb_temp)})
         vref = reports.get(v.OTGW_REPORT_VREF)
         if vref is not None:
-            status.update({v.OTGW_VREF: int(vref)})
+            status_otgw.update({v.OTGW_VREF: int(vref)})
         if ovrd_mode is not None and ovrd_mode != v.OTGW_SETP_OVRD_DISABLED:
-            status[v.DATA_ROOM_SETPOINT_OVRD] = float(
-                reports[v.OTGW_REPORT_SETPOINT_OVRD][1:]
-            )
-        self._update_status(status)
+            status_thermostat = {
+                v.DATA_ROOM_SETPOINT_OVRD: float(
+                    reports[v.OTGW_REPORT_SETPOINT_OVRD][1:]
+                )
+            }
+            self._update_status(v.THERMOSTAT, status_thermostat)
+        self._update_status(v.OTGW, status_otgw)
         return dict(self._protocol.status)
 
     async def get_status(self):
@@ -395,7 +402,8 @@ class pyotgw:
             v.DATA_DHW_PUMP_HOURS: int(fields[23]),
             v.DATA_DHW_BURNER_HOURS: int(fields[24]),
         }
-        self._update_status(status)
+        self._update_status(v.BOILER, status)
+        self._update_status(v.THERMOSTAT, status)
         return dict(self._protocol.status)
 
     async def set_hot_water_ovrd(self, state, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -412,15 +420,15 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_HOT_WATER
-        status = {}
+        status_otgw = {}
         ret = await self._wait_for_cmd(cmd, state, timeout)
         if ret is None:
             return
         if ret == "A":
-            status[v.OTGW_DHW_OVRD] = None
+            status_otgw[v.OTGW_DHW_OVRD] = None
         elif ret in ["0", "1"]:
-            status[v.OTGW_DHW_OVRD] = int(ret)
-        self._update_status(status)
+            status_otgw[v.OTGW_DHW_OVRD] = int(ret)
+        self._update_status(v.OTGW, status_otgw)
         return ret
 
     def get_mode(self):
@@ -430,7 +438,7 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(v.OTGW_MODE)
+        return self._protocol.status[v.OTGW].get(v.OTGW_MODE)
 
     async def set_mode(self, mode, timeout=v.OTGW_DEFAULT_TIMEOUT):
         """
@@ -444,17 +452,17 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_MODE
-        status = {}
+        status_otgw = {}
         ret = await self._wait_for_cmd(cmd, mode, timeout)
         if ret is None:
             return
         if mode is v.OTGW_MODE_RESET:
-            self._protocol.status = {}
+            self._protocol.status = {v.BOILER: {}, v.OTGW: {}, v.THERMOSTAT: {}}
             await self.get_reports()
             await self.get_status()
             return dict(self._protocol.status)
-        status[v.OTGW_MODE] = ret
-        self._update_status(status)
+        status_otgw[v.OTGW_MODE] = ret
+        self._update_status(v.OTGW, status_otgw)
         return ret
 
     def get_led_mode(self, led_id):
@@ -464,7 +472,7 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(getattr(v, f"OTGW_LED_{led_id}"))
+        return self._protocol.status[v.OTGW].get(getattr(v, f"OTGW_LED_{led_id}"))
 
     async def set_led_mode(self, led_id, mode, timeout=v.OTGW_DEFAULT_TIMEOUT):
         """
@@ -492,13 +500,13 @@ class pyotgw:
         """
         if led_id in "ABCDEF" and mode in "RXTBOFHWCEMP":
             cmd = getattr(v, f"OTGW_CMD_LED_{led_id}")
-            status = {}
+            status_otgw = {}
             ret = await self._wait_for_cmd(cmd, mode, timeout)
             if ret is None:
                 return
             var = getattr(v, f"OTGW_LED_{led_id}")
-            status[var] = ret
-            self._update_status(status)
+            status_otgw[var] = ret
+            self._update_status(v.OTGW, status_otgw)
             return ret
 
     def get_gpio_mode(self, gpio_id):
@@ -508,7 +516,7 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(getattr(v, f"OTGW_GPIO_{gpio_id}"))
+        return self._protocol.status[v.OTGW].get(getattr(v, f"OTGW_GPIO_{gpio_id}"))
 
     async def set_gpio_mode(self, gpio_id, mode, timeout=v.OTGW_DEFAULT_TIMEOUT):
         """
@@ -541,18 +549,18 @@ class pyotgw:
             if mode == 7 and gpio_id != "B":
                 return None
             cmd = getattr(v, f"OTGW_CMD_GPIO_{gpio_id}")
-            status = {}
+            status_otgw = {}
             ret = await self._wait_for_cmd(cmd, mode, timeout)
             if ret is None:
                 return
             ret = int(ret)
             var = getattr(v, f"OTGW_GPIO_{gpio_id}")
-            status[var] = ret
-            self._update_status(status)
+            status_otgw[var] = ret
+            self._update_status(v.OTGW, status_otgw)
             asyncio.ensure_future(
                 self._poll_gpio(
-                    self._protocol.status.get(v.OTGW_GPIO_A)
-                    or self._protocol.status.get(v.OTGW_GPIO_B)
+                    self._protocol.status[v.OTGW].get(v.OTGW_GPIO_A)
+                    or self._protocol.status[v.OTGW].get(v.OTGW_GPIO_B)
                 )
             )
             return ret
@@ -563,7 +571,7 @@ class pyotgw:
         """
         if not self._connected:
             return
-        return self._protocol.status.get(v.OTGW_SB_TEMP)
+        return self._protocol.status[v.OTGW].get(v.OTGW_SB_TEMP)
 
     async def set_setback_temp(self, sb_temp, timeout=v.OTGW_DEFAULT_TIMEOUT):
         """
@@ -574,13 +582,13 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_SETBACK
-        status = {}
+        status_otgw = {}
         ret = await self._wait_for_cmd(cmd, sb_temp, timeout)
         if ret is None:
             return
         ret = float(ret)
-        status[v.OTGW_SB_TEMP] = ret
-        self._update_status(status)
+        status_otgw[v.OTGW_SB_TEMP] = ret
+        self._update_status(v.OTGW, status_otgw)
         return ret
 
     async def add_alternative(self, alt, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -712,13 +720,13 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_SET_MAX
-        status = {}
+        status_boiler = {}
         ret = await self._wait_for_cmd(cmd, temperature, timeout)
         if ret is None:
             return
         ret = float(ret)
-        status[v.DATA_MAX_CH_SETPOINT] = ret
-        self._update_status(status)
+        status_boiler[v.DATA_MAX_CH_SETPOINT] = ret
+        self._update_status(v.BOILER, status_boiler)
         return ret
 
     async def set_dhw_setpoint(self, temperature, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -730,13 +738,13 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_SET_WATER
-        status = {}
+        status_boiler = {}
         ret = await self._wait_for_cmd(cmd, temperature, timeout)
         if ret is None:
             return
         ret = float(ret)
-        status[v.DATA_DHW_SETPOINT] = ret
-        self._update_status(status)
+        status_boiler[v.DATA_DHW_SETPOINT] = ret
+        self._update_status(v.BOILER, status_boiler)
         return ret
 
     async def set_max_relative_mod(self, max_mod, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -752,15 +760,15 @@ class pyotgw:
         if isinstance(max_mod, int) and not 0 <= max_mod <= 100:
             return None
         cmd = v.OTGW_CMD_MAX_MOD
-        status = {}
+        status_boiler = {}
         ret = await self._wait_for_cmd(cmd, max_mod, timeout)
         if ret not in ["-", None]:
             ret = int(ret)
         if ret == "-":
-            status[v.DATA_SLAVE_MAX_RELATIVE_MOD] = None
+            status_boiler[v.DATA_SLAVE_MAX_RELATIVE_MOD] = None
         else:
-            status[v.DATA_SLAVE_MAX_RELATIVE_MOD] = ret
-        self._update_status(status)
+            status_boiler[v.DATA_SLAVE_MAX_RELATIVE_MOD] = ret
+        self._update_status(v.BOILER, status_boiler)
         return ret
 
     async def set_control_setpoint(self, setpoint, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -772,13 +780,13 @@ class pyotgw:
         This method is a coroutine
         """
         cmd = v.OTGW_CMD_CONTROL_SETPOINT
-        status = {}
+        status_boiler = {}
         ret = await self._wait_for_cmd(cmd, setpoint, timeout)
         if ret is None:
             return
         ret = float(ret)
-        status[v.DATA_CONTROL_SETPOINT] = ret
-        self._update_status(status)
+        status_boiler[v.DATA_CONTROL_SETPOINT] = ret
+        self._update_status(v.BOILER, status_boiler)
         return ret
 
     async def set_ch_enable_bit(self, ch_bit, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -795,13 +803,13 @@ class pyotgw:
         if ch_bit not in [0, 1]:
             return None
         cmd = v.OTGW_CMD_CONTROL_HEATING
-        status = {}
+        status_boiler = {}
         ret = await self._wait_for_cmd(cmd, ch_bit, timeout)
         if ret is None:
             return
         ret = int(ret)
-        status[v.DATA_MASTER_CH_ENABLED] = ret
-        self._update_status(status)
+        status_boiler[v.DATA_MASTER_CH_ENABLED] = ret
+        self._update_status(v.BOILER, status_boiler)
         return ret
 
     async def set_ventilation(self, pct, timeout=v.OTGW_DEFAULT_TIMEOUT):
@@ -815,13 +823,13 @@ class pyotgw:
         if not 0 <= pct <= 100:
             return None
         cmd = v.OTGW_CMD_VENT
-        status = {}
+        status_boiler = {}
         ret = await self._wait_for_cmd(cmd, pct, timeout)
         if ret is None:
             return
         ret = int(ret)
-        status[v.DATA_COOLING_CONTROL] = ret
-        self._update_status(status)
+        status_boiler[v.DATA_COOLING_CONTROL] = ret
+        self._update_status(v.BOILER, status_boiler)
         return ret
 
     def subscribe(self, coro):
@@ -903,18 +911,18 @@ class pyotgw:
                         )
                         if ret:
                             pios = ret[2:]
-                            status = {
+                            status_otgw = {
                                 v.OTGW_GPIO_A_STATE: int(pios[0]),
                                 v.OTGW_GPIO_B_STATE: int(pios[1]),
                             }
-                            self._update_status(status)
+                            self._update_status(v.OTGW, status_otgw)
                         await asyncio.sleep(interval)
                     except asyncio.CancelledError:
-                        status = {
+                        status_otgw = {
                             v.OTGW_GPIO_A_STATE: 0,
                             v.OTGW_GPIO_B_STATE: 0,
                         }
-                        self._update_status(status)
+                        self._update_status(v.OTGW, status_otgw)
                         self._gpio_task = None
                         break
 
@@ -922,11 +930,14 @@ class pyotgw:
         elif not poll and self._gpio_task is not None:
             self._gpio_task.cancel()
 
-    def _update_status(self, update):
+    def _update_status(self, part, update):
         """Update the status dict and push it to subscribers."""
+        if part not in self._protocol.status:
+            _LOGGER.error(f"Invalid status part for update: {part}")
+            return
         try:
             if isinstance(update, dict):
-                self._protocol.status.update(update)
+                self._protocol.status[part].update(update)
                 self._protocol._updateq.put_nowait(self._protocol.status)
         except AttributeError:
             _LOGGER.warning(

--- a/pyotgw/pyotgw.py
+++ b/pyotgw/pyotgw.py
@@ -19,6 +19,7 @@
 
 
 import asyncio
+import copy
 import logging
 from asyncio import TimeoutError
 from datetime import datetime
@@ -140,7 +141,7 @@ class pyotgw:
             v.OTGW_GPIO_B
         ):
             await self._poll_gpio(True)
-        return dict(self._protocol.status)
+        return copy.deepcopy(self._protocol.status)
 
     async def disconnect(self):
         """
@@ -335,7 +336,7 @@ class pyotgw:
             }
             self._update_status(v.THERMOSTAT, status_thermostat)
         self._update_status(v.OTGW, status_otgw)
-        return dict(self._protocol.status)
+        return copy.deepcopy(self._protocol.status)
 
     async def get_status(self):
         """
@@ -404,7 +405,7 @@ class pyotgw:
         }
         self._update_status(v.BOILER, status)
         self._update_status(v.THERMOSTAT, status)
-        return dict(self._protocol.status)
+        return copy.deepcopy(self._protocol.status)
 
     async def set_hot_water_ovrd(self, state, timeout=v.OTGW_DEFAULT_TIMEOUT):
         """
@@ -460,7 +461,7 @@ class pyotgw:
             self._protocol.status = {v.BOILER: {}, v.OTGW: {}, v.THERMOSTAT: {}}
             await self.get_reports()
             await self.get_status()
-            return dict(self._protocol.status)
+            return copy.deepcopy(self._protocol.status)
         status_otgw[v.OTGW_MODE] = ret
         self._update_status(v.OTGW, status_otgw)
         return ret
@@ -869,7 +870,7 @@ class pyotgw:
         if len(self._notify) > 0:
             # Each client gets its own copy of the dict.
             asyncio.gather(
-                *[coro(dict(status)) for coro in self._notify], loop=self.loop
+                *[coro(copy.deepcopy(status)) for coro in self._notify], loop=self.loop
             )
 
     async def _wait_for_cmd(self, cmd, value, timeout=v.OTGW_DEFAULT_TIMEOUT):

--- a/pyotgw/vars.py
+++ b/pyotgw/vars.py
@@ -57,6 +57,8 @@ BOILER = "boiler"
 OTGW = "gateway"
 THERMOSTAT = "thermostat"
 
+DEFAULT_STATUS = {BOILER: {}, OTGW: {}, THERMOSTAT: {}}
+
 # MSG_STATUS
 DATA_MASTER_CH_ENABLED = "master_ch_enabled"
 DATA_MASTER_DHW_ENABLED = "master_dhw_enabled"

--- a/pyotgw/vars.py
+++ b/pyotgw/vars.py
@@ -53,6 +53,9 @@ MSG_OTVERS = b"\x7D"
 MSG_MVER = b"\x7E"
 MSG_SVER = b"\x7F"
 
+BOILER = "boiler"
+OTGW = "gateway"
+THERMOSTAT = "thermostat"
 
 # MSG_STATUS
 DATA_MASTER_CH_ENABLED = "master_ch_enabled"


### PR DESCRIPTION
When an override is active on the gateway, there can be discrepancies between the status on the boiler side vs on the thermostat side. This causes certain status attributes to change back and forth between the different values continually.
To fix, we will separate the status on the thermostat side from the status on the boiler side. While we're at it, we also split out the status attributes related to the OpenTherm Gateway itself.

Fixes #19 