### PR TITLE
Add transparent command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 3.9.0
+  rev: 7.0.0
   hooks:
   - id: flake8
     args:

--- a/README.md
+++ b/README.md
@@ -358,6 +358,19 @@ Return the newly accepted value, or `None` on failure.
 This method is a coroutine.
 
 ---
+##### OpenThermGateway.send_transparent_command(_self_, cmd, state, timeout=OTGW_DEFAULT_TIMEOUT)
+Send a transparent command.
+Sends custom commands through a transparent interface.
+Check https://otgw.tclcode.com/firmware.html for supported commands.
+This method supports the following arguments:
+- __cmd__ The supported command e.g. `SC` (set time/day).
+- __state__ The command argument e.g. `23:59/4` (the current time/day)
+
+Returns the gateway response, which should be equal __state__.
+
+This method is a coroutine.
+
+---
 ##### OpenThermGateway.subscribe(_self_, coro)
 Subscribe to status updates from the Opentherm Gateway.
 The subscribed coroutine must have the following signature:

--- a/pyotgw/pyotgw.py
+++ b/pyotgw/pyotgw.py
@@ -781,6 +781,21 @@ class OpenThermGateway:  # pylint: disable=too-many-public-methods
         self.status.submit_partial_update(v.BOILER, status_boiler)
         return ret
 
+    async def send_transparent_command(
+        self, cmd, state, timeout=v.OTGW_DEFAULT_TIMEOUT
+    ):
+        """
+        Sends custom otgw commands throug a transparent interface.
+        Check https://otgw.tclcode.com/firmware.html for supported commands.
+        @cmd the supported command e.g. 'SC' (set time/day)
+        @state the command argument e.g. '23:59/4' (the current time/day)
+        Returns the gateway response, which should be equal to @state.
+
+        This method is a coroutine
+        """
+        ret = await self._wait_for_cmd(cmd, state, timeout)
+        return ret
+
     def subscribe(self, coro):
         """
         Subscribe to status updates from the Opentherm Gateway.


### PR DESCRIPTION
Hi,

I would like to add the feature transparent command to be used in Home Assistant (opentherm integration). I decided not to implement separate commands as it would make the integration more complex by adding dependencies. In addition to this the developer is free to use whatever command is available for the installed otgw firmware.

To provide you with some context:
Recently I made an update to the [otgw firmware](https://github.com/GraceGRD/otgw/tree/feature_itho-wpu5g) to support **Itho WPU5G** boiler commands e.g. `set DHW time` and `set DHW mode (block/standby/boost)`. Sadly this works different from the existing and implemented methods e.g. `set_dhw_setpoint`.

Commands:
`QH=C` Immediately heats up the boiler tank to ~60 degrees. This command is reset automatically after the boiler tank is heated.
`QH=S` Puts DHW mode to standby where only the legionella cycle is ran once a week.  
`QH=B` Blocks the DHW function completely. 
`QI=22:15` Sets the default DHW heating time where the boiler tank is heated once a day (eco & comfort mode)

Only one QH command can be active at a time and the active command can be disabled/aborted by sending an invalid character as command argument.

I have not yet started on the test for this command as I would like to know if you even consider merging this in the next **pyotgw** release. 

Please let me know.